### PR TITLE
feat(software-engineering): add frontmatter to analyze-and-create-issue command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "software-engineering",
       "source": "./plugins/software-engineering",
       "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "Sylvain"
       }

--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ within claude:
 /plugin
 ```
 
+## Development
+
+Use of tool https://github.com/ffurrer2/semver

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-engineering",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
   "author": {
     "name": "Sylvain",

--- a/plugins/software-engineering/commands/analyze-and-create-issue.md
+++ b/plugins/software-engineering/commands/analyze-and-create-issue.md
@@ -1,3 +1,10 @@
+---
+description: Analyze codebase for improvements and create GitHub/GitLab issues for each finding with user confirmation
+argument-hint: "[optional: domain to focus analysis, e.g., 'security', 'performance', 'documentation']"
+allowed-tools: Read, Grep, Glob, Bash, mcp__github__, mcp__gitlab-mcp__
+model: sonnet
+---
+
 # Analyze And Create Issue Command
 
 Analyze codebase to find improvements. For each improvement:


### PR DESCRIPTION
Add YAML frontmatter metadata to analyze-and-create-issue command:
- Add description for better discoverability
- Add argument hints for optional domain focus
- Specify allowed tools for security
- Set model to sonnet

Also update README with semver tool reference and bump plugin version to 0.7.1.