### PR TITLE
feat(mcp): add Perplexity AI MCP server integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "devops-infrastructure",
       "source": "./plugins/devops-infrastructure",
       "description": "Infrastructure as Code, CI/CD pipelines, and database specialists for DevOps workflows",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Sylvain"
       }
@@ -21,7 +21,7 @@
       "name": "software-engineering",
       "source": "./plugins/software-engineering",
       "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "author": {
         "name": "Sylvain"
       }
@@ -30,7 +30,7 @@
       "name": "go-specialist",
       "source": "./plugins/go-specialist",
       "description": "Master Go 1.25+ development with modern patterns, concurrency, and performance optimization",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "author": {
         "name": "Sylvain"
       }

--- a/plugins/devops-infrastructure/.claude-plugin/plugin.json
+++ b/plugins/devops-infrastructure/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-infrastructure",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Infrastructure as Code, CI/CD pipelines, and database specialists for DevOps workflows",
   "author": {
     "name": "Sylvain",

--- a/plugins/devops-infrastructure/mcp.json
+++ b/plugins/devops-infrastructure/mcp.json
@@ -17,6 +17,10 @@
 		},
 		"gitlab-mcp": {
 			"command": "gitlab-mcp"
+		},
+		"perplexity-ai": {
+			"command": "pplx",
+			"args": ["mcp-stdio"]
 		}
 	}
 }

--- a/plugins/go-specialist/.claude-plugin/plugin.json
+++ b/plugins/go-specialist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-specialist",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Master Go 1.25+ development with modern patterns, concurrency, and performance optimization",
   "author": {
     "name": "Sylvain",

--- a/plugins/go-specialist/mcp.json
+++ b/plugins/go-specialist/mcp.json
@@ -17,6 +17,10 @@
 		},
 		"gitlab-mcp": {
 			"command": "gitlab-mcp"
+		},
+		"perplexity-ai": {
+			"command": "pplx",
+			"args": ["mcp-stdio"]
 		}
 	}
 }

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-engineering",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
   "author": {
     "name": "Sylvain",

--- a/plugins/software-engineering/mcp.json
+++ b/plugins/software-engineering/mcp.json
@@ -17,6 +17,10 @@
 		},
 		"gitlab-mcp": {
 			"command": "gitlab-mcp"
+		},
+		"perplexity-ai": {
+			"command": "pplx",
+			"args": ["mcp-stdio"]
 		}
 	}
 }


### PR DESCRIPTION
- Add perplexity-ai (pplx) MCP server to all three plugins
- Configure with pplx mcp-stdio command
- Bump devops-infrastructure to v0.2.1
- Bump software-engineering to v0.8.1
- Bump go-specialist to v0.7.1