### PR TITLE
feat(hooks): add PostToolUse hooks for automatic agent activation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "devops-infrastructure",
       "source": "./plugins/devops-infrastructure",
       "description": "Infrastructure as Code, CI/CD pipelines, and database specialists for DevOps workflows",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "Sylvain"
       }
@@ -21,7 +21,7 @@
       "name": "software-engineering",
       "source": "./plugins/software-engineering",
       "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "author": {
         "name": "Sylvain"
       }
@@ -30,7 +30,7 @@
       "name": "go-specialist",
       "source": "./plugins/go-specialist",
       "description": "Master Go 1.25+ development with modern patterns, concurrency, and performance optimization",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "Sylvain"
       }

--- a/plugins/devops-infrastructure/.claude-plugin/plugin.json
+++ b/plugins/devops-infrastructure/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "devops-infrastructure",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Infrastructure as Code, CI/CD pipelines, and database specialists for DevOps workflows",
   "author": {
     "name": "Sylvain",

--- a/plugins/devops-infrastructure/hooks.json
+++ b/plugins/devops-infrastructure/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "A file was just modified. Analyze the file path ($ARGUMENTS.tool_input.file_path):\n- If it's a Terraform file (.tf, .tfvars), invoke devops-specialist for infrastructure code review\n- If it's a SQL file (.sql) or in a migrations/ directory, invoke database-specialist for query optimization and schema review\n- If it's a CloudFormation template (.yml/.yaml with 'AWSTemplateFormatVersion'), invoke devops-specialist\n- If it's an Ansible playbook (.yml in ansible/playbooks), invoke devops-specialist"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/go-specialist/.claude-plugin/plugin.json
+++ b/plugins/go-specialist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-specialist",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Master Go 1.25+ development with modern patterns, concurrency, and performance optimization",
   "author": {
     "name": "Sylvain",

--- a/plugins/go-specialist/hooks.json
+++ b/plugins/go-specialist/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "A file was just modified via $ARGUMENTS.tool_name. Check if the file path ($ARGUMENTS.tool_input.file_path) is a Go source file (.go), go.mod, or go.sum. If yes, proactively invoke the golang-pro agent to provide Go language expertise, code review, performance optimization suggestions, or architectural guidance for the Go code."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-engineering",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
   "author": {
     "name": "Sylvain",

--- a/plugins/software-engineering/hooks.json
+++ b/plugins/software-engineering/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "A source code file was just modified. Analyze the context:\n1. Check if file extension is .go, .ts, .js, .py, .java, or .rs - if yes, invoke code-review-enforcer agent for comprehensive code review\n2. Check if file path contains 'auth', 'crypto', 'jwt', 'session', 'password', 'secret', or 'security' - if yes, ALSO invoke security-auditor agent for security vulnerability analysis\n\nFile path: $ARGUMENTS.tool_input.file_path\n\nNote: security-auditor requires manual user approval (permissionMode: manual)."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add hooks.json configuration to all plugins to enable proactive agent invocation:
- devops-infrastructure: Auto-invoke specialists for .tf, .sql, CloudFormation, and Ansible files
- go-specialist: Auto-invoke golang-pro for .go, go.mod, and go.sum file modifications
- software-engineering: Auto-invoke code-review-enforcer and security-auditor for source code changes

Bump plugin versions to 0.2.2, 0.7.2, and 0.8.2 respectively.