### PR TITLE
fix(go-specialist): use go-version-file in GitHub workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
       "name": "go-specialist",
       "source": "./plugins/go-specialist",
       "description": "Master Go 1.25+ development with modern patterns, concurrency, and performance optimization",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "author": {
         "name": "Sylvain"
       }

--- a/plugins/go-specialist/.claude-plugin/plugin.json
+++ b/plugins/go-specialist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-specialist",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Master Go 1.25+ development with modern patterns, advanced concurrency, performance optimization, and production-ready microservices. Skills: golangci-lint, goreleaser, GitHub Actions, GitLab CI. MCP: task-master-ai, github, gitlab-mcp, perplexity-ai, context7",
   "author": {
     "name": "Sylvain",

--- a/plugins/go-specialist/commands/assets/github-workflows/workflows/coverage.yml
+++ b/plugins/go-specialist/commands/assets/github-workflows/workflows/coverage.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: actions/checkout@v5
 
       # Setup Go environment
-      # CUSTOMIZE: Adjust Go version to match your project
+      # Uses Go version from go.mod for consistency
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x  # CUSTOMIZE: Use your Go version
+          go-version-file: 'go.mod'
 
       # Run tests with coverage
       # CUSTOMIZE: Adjust coverage commands for your project structure

--- a/plugins/go-specialist/commands/assets/github-workflows/workflows/linter.yml
+++ b/plugins/go-specialist/commands/assets/github-workflows/workflows/linter.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v5
 
       # Setup Go environment
-      # CUSTOMIZE: Adjust Go version to match your project
+      # Uses Go version from go.mod for consistency
       - uses: actions/setup-go@v6
         with:
-          go-version: stable  # Options: stable, 1.24, 1.24.x, >=1.23
+          go-version-file: 'go.mod'
 
       # Install Task runner
       # Task provides consistent build commands across local and CI

--- a/plugins/go-specialist/commands/assets/github-workflows/workflows/release.yml
+++ b/plugins/go-specialist/commands/assets/github-workflows/workflows/release.yml
@@ -35,11 +35,11 @@ jobs:
           fetch-depth: 0  # Required for GoReleaser changelog generation
 
       # Setup Go environment
-      # CUSTOMIZE: Adjust Go version to match your project
+      # Uses Go version from go.mod for consistency
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24'  # CUSTOMIZE: Use your Go version
+          go-version-file: 'go.mod'
 
       # Install Task runner
       # Task provides consistent build commands across local and CI

--- a/plugins/go-specialist/commands/assets/github-workflows/workflows/snapshot.yml
+++ b/plugins/go-specialist/commands/assets/github-workflows/workflows/snapshot.yml
@@ -28,11 +28,11 @@ jobs:
           fetch-depth: 0  # Required for GoReleaser changelog
 
       # Setup Go environment
-      # CUSTOMIZE: Adjust Go version to match your project
+      # Uses Go version from go.mod for consistency
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24'  # CUSTOMIZE: Use your Go version
+          go-version-file: 'go.mod'
 
       # Install Task runner
       # Task provides consistent build commands across local and CI


### PR DESCRIPTION
Replace hardcoded Go versions with go-version-file: 'go.mod' in all
GitHub Actions workflows (linter, coverage, release, snapshot) to ensure
CI/CD uses the same Go version specified in go.mod.

This eliminates version drift and requires no manual workflow updates
when Go version changes.

Bump plugin version to 0.10.1