### PR TITLE
chore(plugins): bump versions and remove unused MCP server

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "software-engineering",
       "source": "./plugins/software-engineering",
       "description": "Code review, debugging, documentation, licensing, payments, and frontend development workflows",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "author": {
         "name": "Sylvain"
       }
@@ -30,7 +30,7 @@
       "name": "go-specialist",
       "source": "./plugins/go-specialist",
       "description": "Master Go 1.25+ development with modern patterns, concurrency, and performance optimization",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "author": {
         "name": "Sylvain"
       }

--- a/plugins/go-specialist/.claude-plugin/plugin.json
+++ b/plugins/go-specialist/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "go-specialist",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Master Go 1.25+ development with modern patterns, advanced concurrency, performance optimization, and production-ready microservices. Skills: golangci-lint, goreleaser, GitHub Actions, GitLab CI. MCP: task-master-ai, github, gitlab-mcp, perplexity-ai, context7",
   "author": {
     "name": "Sylvain",

--- a/plugins/go-specialist/mcp.json
+++ b/plugins/go-specialist/mcp.json
@@ -1,13 +1,5 @@
 {
 	"mcpServers": {
-		"task-master-ai": {
-			"type": "stdio",
-			"command": "npx",
-			"args": [
-				"-y",
-				"task-master-ai"
-			]
-		},
 		"github": {
 			"transport": "http",
 			"url": "https://api.githubcopilot.com/mcp",

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-engineering",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Code review, debugging, documentation, license compliance (AGPL/MIT/Apache), payment integration (Stripe/PayPal), and frontend development (HTMX/Alpine.js) workflows. MCP: task-master-ai, github, gitlab-mcp, perplexity-ai, context7",
   "author": {
     "name": "Sylvain",

--- a/plugins/software-engineering/commands/feature-flow.md
+++ b/plugins/software-engineering/commands/feature-flow.md
@@ -198,8 +198,7 @@ git remote -v
    - Format: `- [Action] [what changed]`
 
 5. **Add footer:**
-   - If issue created: `Refs #<issue-number>`
-   - If issue exists: `Closes #<issue-number>` (for fixes)
+   - `Closes #<issue-number>` (for fixes)
    - Never include breaking changes without user consent
 
 **Format example:**


### PR DESCRIPTION
- Increment go-specialist to v0.10.2
- Increment software-engineering to v0.12.1
- Remove task-master-ai MCP server from go-specialist
- Clean up feature-flow commit footer documentation

Closes #27