### PR TITLE
fix(commands): fix typo 'thoses' to 'those' in label guidelines

### DIFF
--- a/plugins/software-engineering/commands/analyze-and-create-issue.md
+++ b/plugins/software-engineering/commands/analyze-and-create-issue.md
@@ -39,7 +39,7 @@ git remote -v
   - Expected behavior
   - Current behavior
   - Additional context or screenshots
-- **Labels**: Suggest appropriate labels based on thoses available in the host repository.
+- **Labels**: Suggest appropriate labels based on those available in the host repository.
 
 ### Formatting:
 - Use proper markdown formatting

--- a/plugins/software-engineering/commands/create-issue.md
+++ b/plugins/software-engineering/commands/create-issue.md
@@ -39,7 +39,7 @@ The issue content should be based on: `$argument`
   - Expected behavior
   - Current behavior
   - Additional context or screenshots
-- **Labels**: Suggest appropriate labels based on thoses available in the host repository.
+- **Labels**: Suggest appropriate labels based on those available in the host repository.
 
 ### Formatting:
 - Use proper markdown formatting


### PR DESCRIPTION
## Summary\n- Fix typo `thoses` → `those` in `analyze-and-create-issue.md`\n- Fix typo `thoses` → `those` in `create-issue.md`\n\nCloses #38