### PR TITLE
fix(agents): remove phantom task-checker references

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/user
 - `license-specialist` - Open source license compliance for SaaS
 - `payment-integrator` - Stripe, PayPal, subscription billing
 - `security-auditor` - Security vulnerability detection
-- `task-checker` - Task validation and QA
 
 **Commands**:
 - `/analyze-and-create-issue` - Analyze codebase issues and create GitHub/GitLab issues

--- a/plugins/software-engineering/agents/code-review-enforcer.md
+++ b/plugins/software-engineering/agents/code-review-enforcer.md
@@ -13,7 +13,6 @@ model: sonnet
 color: purple
 context: |
   Reviews code changes made by other agents or developers.
-  Shares quality standards with task-checker for validation alignment.
   Enforces security patterns in coordination with security-auditor.
 ---
 

--- a/plugins/software-engineering/agents/debugger.md
+++ b/plugins/software-engineering/agents/debugger.md
@@ -13,7 +13,6 @@ model: sonnet
 color: orange
 context: |
   Analyzes errors and shares root cause findings with implementing agents.
-  Coordinates with task-checker when debugging test failures.
   Provides diagnostic insights to inform code-review-enforcer security analysis.
 ---
 
@@ -187,7 +186,6 @@ For each issue investigated, provide:
 
 ## Coordination with Other Agents
 
-- **task-checker**: Share test failure analysis for quality validation
 - **code-review-enforcer**: Provide error patterns for proactive detection
 - **security-auditor**: Escalate security-related errors for review
 - **Language specialists (golang-pro, etc.)**: Leverage language-specific debugging expertise

--- a/plugins/software-engineering/agents/security-auditor.md
+++ b/plugins/software-engineering/agents/security-auditor.md
@@ -242,7 +242,6 @@ Risk Level: 🔴 Critical | 🟠 High | 🟡 Medium | 🟢 Low
 ## Coordination with Other Agents
 
 - **code-review-enforcer**: Share security findings for holistic quality review
-- **task-checker**: Validate security requirements in task acceptance criteria
 - **debugger**: Investigate security-related errors and anomalies
 - **golang-pro/language specialists**: Enforce language-specific security patterns
 


### PR DESCRIPTION
- Remove task-checker from code-review-enforcer context field
- Remove task-checker from debugger context field and coordination section
- Remove task-checker from security-auditor coordination section
- Remove task-checker from README.md agent list

Closes #60