### PR TITLE
feat(commands): add missing H1 title to audit-codebase command

### DIFF
--- a/plugins/software-engineering/commands/audit-codebase.md
+++ b/plugins/software-engineering/commands/audit-codebase.md
@@ -5,6 +5,8 @@ argument-hint: "[optional: focus area e.g., 'security', 'performance', 'best-pra
 allowed-tools: Read, Grep, Glob, Bash(find:*), Bash(wc:*), Task
 ---
 
+# Audit Codebase Command
+
 Audit the code for potential security vulnerabilities, performance issues, and adherence to best practices. Provide a detailed report with recommendations for improvements.
 
 ## Process


### PR DESCRIPTION
- Add `# Audit Codebase Command` heading after frontmatter
- Align with all other commands that use H1 as first content line

Closes #75