### PR TITLE
fix(go-specialist): replace incorrect Context7 tool name (Closes #66)

### DIFF
--- a/plugins/go-specialist/agents/golang-pro.md
+++ b/plugins/go-specialist/agents/golang-pro.md
@@ -79,9 +79,8 @@ When implementing features using third-party Go libraries:
    - Example: User mentions "I want to use Gin framework" → resolve "gin-gonic/gin"
 
 2. **Documentation Retrieval**:
-   - Use `mcp__context7__get-library-docs` with mode='code' for API references
-   - Use mode='info' for conceptual guides and architecture
-   - Paginate through documentation as needed (page=1, page=2, etc.)
+   - Use `mcp__context7__query-docs` with the resolved library ID
+   - Provide specific queries for API references or conceptual guides
 
 3. **Code Generation**:
    - Generate code using official library patterns from Context7
@@ -92,7 +91,7 @@ When implementing features using third-party Go libraries:
 ```
 User: "Add HTTP middleware for logging using Gin"
 → resolve-library-id: "gin-gonic/gin"
-→ get-library-docs: "/gin-gonic/gin" topic="middleware" mode="code"
+→ query-docs: "/gin-gonic/gin" query="middleware"
 → Generate middleware using official Gin patterns
 → Include links to Gin documentation
 ```

--- a/plugins/go-specialist/commands/verify-task.md
+++ b/plugins/go-specialist/commands/verify-task.md
@@ -30,7 +30,7 @@ Verify the quality and completeness of a task implementation. This command valid
    **Agent #1: Library Usage Validator (Context7 Integration)**
    - Extract all third-party Go libraries from import statements
    - For each library, use `mcp__context7__resolve-library-id` to identify library
-   - Use `mcp__context7__get-library-docs` to fetch official documentation
+   - Use `mcp__context7__query-docs` to fetch official documentation
    - Verify code follows official library patterns and best practices
    - Check for deprecated APIs or outdated usage
    - Validate proper usage of library features and idioms
@@ -103,9 +103,9 @@ Note: If task uses multiple third-party libraries (e.g., 5+ imports), fetch Cont
 
 ```
 # Example: 3 libraries
-Task(tool: "mcp__context7__get-library-docs", library: "/gin-gonic/gin")
-Task(tool: "mcp__context7__get-library-docs", library: "/go-chi/chi")
-Task(tool: "mcp__context7__get-library-docs", library: "/gorilla/mux")
+Task(tool: "mcp__context7__query-docs", library: "/gin-gonic/gin")
+Task(tool: "mcp__context7__query-docs", library: "/go-chi/chi")
+Task(tool: "mcp__context7__query-docs", library: "/gorilla/mux")
 # Results aggregated after all complete
 ```
 


### PR DESCRIPTION
- Replace mcp__context7__get-library-docs with mcp__context7__query-docs
  in golang-pro.md body text and verify-task.md process instructions
- Update example workflow to match current Context7 MCP API