### PR TITLE
fix(skills): remove unsupported frontmatter fields from detect-repo-host

### DIFF
--- a/plugins/software-engineering/skills/detect-repo-host/SKILL.md
+++ b/plugins/software-engineering/skills/detect-repo-host/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: detect-repo-host
 description: Detect repository hosting service (GitHub/GitLab) from git remote and extract owner/repo/project_path. Internal utility skill used by commands that need platform-aware routing.
-version: 1.0.0
-author: sylvain
-license: MIT
 user-invocable: false
 allowed-tools: Bash(git remote:*)
 ---


### PR DESCRIPTION
Remove version, author, and license fields from detect-repo-host SKILL.md
as they are not supported by the Claude Code skill engine per official docs.
The prd skill was already removed in a prior commit.

Closes #72