### PR TITLE
feat(manifests): add homepage field to plugin.json (Closes #90)

### DIFF
--- a/plugins/devops-infrastructure/.claude-plugin/plugin.json
+++ b/plugins/devops-infrastructure/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
     "email": "1552102+sgaunet@users.noreply.github.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/sgaunet/claude-plugins"
+  "repository": "https://github.com/sgaunet/claude-plugins",
+  "homepage": "https://github.com/sgaunet/claude-plugins#readme"
 }

--- a/plugins/go-specialist/.claude-plugin/plugin.json
+++ b/plugins/go-specialist/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
     "email": "1552102+sgaunet@users.noreply.github.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/sgaunet/claude-plugins"
+  "repository": "https://github.com/sgaunet/claude-plugins",
+  "homepage": "https://github.com/sgaunet/claude-plugins#readme"
 }

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -8,5 +8,6 @@
     "email": "1552102+sgaunet@users.noreply.github.com"
   },
   "license": "MIT",
-  "repository": "https://github.com/sgaunet/claude-plugins"
+  "repository": "https://github.com/sgaunet/claude-plugins",
+  "homepage": "https://github.com/sgaunet/claude-plugins#readme"
 }


### PR DESCRIPTION
## Summary

- Add `"homepage": "https://github.com/sgaunet/claude-plugins#readme"` to all 3 `plugin.json` manifests
- Improves plugin discoverability per the official schema

## Affected Files

- `plugins/devops-infrastructure/.claude-plugin/plugin.json`
- `plugins/go-specialist/.claude-plugin/plugin.json`
- `plugins/software-engineering/.claude-plugin/plugin.json`

## Test Plan

- [x] `task lint` passes (plugin validation, version sync, frontmatter validation)

Closes #90