### PR TITLE
fix(software-engineering): always close issue and assign to creator in feature-flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "sylvain-marketplace",
   "metadata": {
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "Specialized Claude Code agents for DevOps infrastructure, software engineering workflows, and Go development. Includes proactive agents for IaC, CI/CD, database optimization, code review, debugging, documentation, and more."
   },
   "owner": {
@@ -22,7 +22,7 @@
       "name": "software-engineering",
       "source": "./plugins/software-engineering",
       "description": "Code review, debugging, documentation, license compliance (AGPL/MIT/Apache), payment integration (Stripe/PayPal), and frontend development (HTMX/Alpine.js) workflows. MCP: context7",
-      "version": "0.14.6",
+      "version": "0.14.7",
       "author": {
         "name": "Sylvain"
       }

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-engineering",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Code review, debugging, documentation, license compliance (AGPL/MIT/Apache), payment integration (Stripe/PayPal), and frontend development (HTMX/Alpine.js) workflows. MCP: context7",
   "keywords": [
     "code-review",

--- a/plugins/software-engineering/commands/feature-flow-w.md
+++ b/plugins/software-engineering/commands/feature-flow-w.md
@@ -105,8 +105,8 @@ Store `<worktree-path>` and `<original-path>` (result of `pwd`) for use througho
 3. Display preview, ask confirmation: "Create issue with this content?" → "Yes, create issue" / "Skip issue creation"
 
 4. Create issue if approved:
-   - GitHub: `gh issue create --repo <owner>/<repo> --title "<title>" --body "<body>" --label "<label1>" --label "<label2>"`
-   - GitLab: `glab issue create --title "<title>" --description "<body>" --label "<label1>" --label "<label2>"`
+   - GitHub: `gh issue create --repo <owner>/<repo> --title "<title>" --body "<body>" --label "<label1>" --label "<label2>" --assignee @me`
+   - GitLab: `glab issue create --title "<title>" --description "<body>" --label "<label1>" --label "<label2>" --assignee "$(glab api user | jq -r '.username')"`
    - Parse issue number from command output; store for Phase 4
 
 **Error handling:**
@@ -123,7 +123,7 @@ Store `<worktree-path>` and `<original-path>` (result of `pwd`) for use througho
 - Scope from primary directory
 - Description: imperative mood, lowercase, under 50 chars, no period
 - Body: bullet points for multi-file changes
-- Footer: `Refs #<issue-number>` or `Closes #<N>` for fixes
+- Footer: `Closes #<issue-number>` (always use `Closes`, not `Refs`, when an issue was created in Phase 3)
 - **CRITICAL**: NO Claude Code attribution (per commit command's no-attribution policy)
 
 **Display preview, ask confirmation:** "Commit with this message?" → "Yes, commit now" / "Edit message" / "Cancel workflow"

--- a/plugins/software-engineering/commands/feature-flow.md
+++ b/plugins/software-engineering/commands/feature-flow.md
@@ -80,8 +80,8 @@ Staged Mode examples: `/feature-flow`, `/feature-flow add user auth`, `/feature-
 3. Display preview, ask confirmation: "Create issue with this content?" → "Yes, create issue" / "Skip issue creation"
 
 4. Create issue if approved:
-   - GitHub: `gh issue create --repo <owner>/<repo> --title "<title>" --body "<body>" --label "<label1>" --label "<label2>"`
-   - GitLab: `glab issue create --title "<title>" --description "<body>" --label "<label1>" --label "<label2>"`
+   - GitHub: `gh issue create --repo <owner>/<repo> --title "<title>" --body "<body>" --label "<label1>" --label "<label2>" --assignee @me`
+   - GitLab: `glab issue create --title "<title>" --description "<body>" --label "<label1>" --label "<label2>" --assignee "$(glab api user | jq -r '.username')"`
    - Parse issue number from command output; store for Phase 4
 
 **Error handling:**
@@ -96,7 +96,7 @@ Staged Mode examples: `/feature-flow`, `/feature-flow add user auth`, `/feature-
 - Scope from primary directory
 - Description: imperative mood, lowercase, under 50 chars, no period
 - Body: bullet points for multi-file changes
-- Footer: `Refs #<issue-number>` or `Closes #<N>` for fixes
+- Footer: `Closes #<issue-number>` (always use `Closes`, not `Refs`, when an issue was created in Phase 3)
 - **CRITICAL**: NO Claude Code attribution (per commit command's no-attribution policy)
 
 **Display preview, ask confirmation:** "Commit with this message?" → "Yes, commit now" / "Edit message" / "Cancel workflow"


### PR DESCRIPTION
- Use Closes #<N> instead of Refs #<N> in commit footer when issue was created
- Add --assignee @me (gh) / glab API username lookup (glab) to issue creation
- Apply to both feature-flow and feature-flow-w commands

Closes #142