### PR TITLE
feat(no-leak): add gitleaks content scanning as Layer 2

### DIFF
--- a/extras/no-leak/configure-no-leak.sh
+++ b/extras/no-leak/configure-no-leak.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install no-leak PreToolUse hook into Claude Code user settings
-# Copies no-leak.sh to ~/.claude/ and merges hook config into settings.json
+# Copies no-leak.sh and gitleaks.toml to ~/.claude/ and merges hook config into settings.json
 
 set -euo pipefail
 
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLAUDE_DIR="$HOME/.claude"
 SETTINGS="$CLAUDE_DIR/settings.json"
 TARGET="$CLAUDE_DIR/no-leak.sh"
+GITLEAKS_TARGET="$CLAUDE_DIR/gitleaks.toml"
 
 # --- Prerequisites ---
 
@@ -24,11 +25,32 @@ if [[ ! -d "$CLAUDE_DIR" ]]; then
   exit 1
 fi
 
+# --- Soft prerequisites ---
+
+if command -v gitleaks &>/dev/null; then
+  echo "Found:     gitleaks $(gitleaks version 2>/dev/null)"
+else
+  echo "Warning:   gitleaks not found. Content scanning will be disabled."
+  echo "           Install it for full protection:"
+  echo "             macOS:  brew install gitleaks"
+  echo "             Linux:  https://github.com/gitleaks/gitleaks#installation"
+  echo ""
+  echo "           The hook will still block based on filename patterns."
+  echo ""
+fi
+
 # --- Install hook script ---
 
 cp "$SCRIPT_DIR/no-leak.sh" "$TARGET"
 chmod +x "$TARGET"
 echo "Installed: $TARGET"
+
+# --- Install gitleaks config ---
+
+if [[ -f "$SCRIPT_DIR/gitleaks.toml" ]]; then
+  cp "$SCRIPT_DIR/gitleaks.toml" "$GITLEAKS_TARGET"
+  echo "Installed: $GITLEAKS_TARGET"
+fi
 
 # --- Update settings.json ---
 
@@ -68,9 +90,16 @@ echo "Updated:   $SETTINGS"
 echo ""
 echo "Done! Restart Claude Code to activate the no-leak hook."
 echo ""
-echo "Test it with:"
+echo "Test filename blocking:"
 echo '  echo '\''{"tool_name":"Read","tool_input":{"file_path":".env"}}'\'' | ~/.claude/no-leak.sh'
 echo '  # Expected: exit code 2 (blocked)'
 echo ""
 echo '  echo '\''{"tool_name":"Read","tool_input":{"file_path":"main.go"}}'\'' | ~/.claude/no-leak.sh'
 echo '  # Expected: exit code 0 (allowed)'
+echo ""
+echo "Test gitleaks content scanning (requires gitleaks):"
+echo '  echo '\''{"tool_name":"Write","tool_input":{"file_path":"x.yml","content":"key = AKIAIOSFODNN7EXAMPLO"}}'\'' | ~/.claude/no-leak.sh'
+echo '  # Expected: exit code 2 (blocked by gitleaks)'
+echo ""
+echo "Disable gitleaks temporarily:"
+echo '  GITLEAKS_DISABLED=1 your-command'

--- a/extras/no-leak/gitleaks.toml
+++ b/extras/no-leak/gitleaks.toml
@@ -1,0 +1,54 @@
+# Gitleaks configuration for Claude Code no-leak hook
+# Extends the default gitleaks ruleset with custom DSN detection rules.
+# Installed to: ~/.claude/gitleaks.toml
+# Docs: https://github.com/gitleaks/gitleaks#configuration
+
+[extend]
+useDefault = true
+
+# --- Custom rule: Database/service connection strings with embedded credentials ---
+# Detects: postgres://, postgresql://, mysql://, mongodb://, mongodb+srv://,
+#          redis://, rediss://, amqp://, amqps:// with user:password@host patterns.
+
+[[rules]]
+id = "dsn-credentials"
+description = "Connection string (DSN) with embedded credentials"
+regex = '''(?i)(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis(?:s)?|amqps?)://[^\s'"]+:[^\s'"]+@[^\s'"]+'''
+keywords = ["postgres", "postgresql", "mysql", "mongodb", "redis", "amqp"]
+tags = ["dsn", "credentials"]
+
+  [[rules.allowlists]]
+  description = "Allow localhost, loopback, example domains, common test credentials, and docker-compose service names"
+  regexTarget = "match"
+  regexes = [
+    # Localhost and loopback
+    '''@localhost[:/]''',
+    '''@127\.0\.0\.1[:/]''',
+    '''@\[::1\][:/]''',
+
+    # Common test/example credentials
+    '''://user:password@''',
+    '''://root:root@''',
+    '''://test:test@''',
+    '''://postgres:postgres@''',
+    '''://admin:admin@''',
+    '''://guest:guest@''',
+    '''://default:default@''',
+
+    # RFC 2606 reserved example domains
+    '''@example\.com''',
+    '''@example\.net''',
+    '''@example\.org''',
+
+    # Docker Compose service name patterns (bare hostname:port)
+    '''@db:''',
+    '''@database:''',
+    '''@redis:''',
+    '''@mongo:''',
+    '''@mongodb:''',
+    '''@mysql:''',
+    '''@postgres:''',
+    '''@postgresql:''',
+    '''@rabbitmq:''',
+    '''@amqp:'''
+  ]

--- a/extras/no-leak/install-no-leak.md
+++ b/extras/no-leak/install-no-leak.md
@@ -1,8 +1,19 @@
 # No-Leak Hook for Claude Code
 
-A `PreToolUse` hook that prevents Claude Code from reading or modifying sensitive files (`.env`, credentials, private keys, vault files). Unlike CLAUDE.md instructions which Claude may overlook, hooks are **deterministic** — the LLM cannot bypass them.
+A `PreToolUse` hook that prevents Claude Code from reading or modifying sensitive files and content. Unlike CLAUDE.md instructions which Claude may overlook, hooks are **deterministic** — the LLM cannot bypass them.
+
+## Two-Layer Protection
+
+| Layer | What it checks | Dependency |
+|-------|---------------|------------|
+| **1. Filename patterns** | Blocks files matching sensitive names (`.env`, `.pem`, `.key`, etc.) | jq (required) |
+| **2. Content scanning** | Scans file content for secrets (API keys, tokens, DSNs with credentials) | gitleaks (optional) |
+
+If gitleaks is not installed, the hook degrades gracefully to filename-only checks.
 
 ## What Gets Blocked
+
+### Layer 1: Filename Patterns
 
 | Pattern | Examples |
 |---------|----------|
@@ -13,11 +24,29 @@ A `PreToolUse` hook that prevents Claude Code from reading or modifying sensitiv
 | `*.pem`, `*.key` | TLS certificates, private keys |
 | `*secret*` | `secret.yaml`, `db-secret.json` |
 
-Applies to: **Read**, **Edit**, **Write**, **Bash**, and **Glob** tool calls.
+### Layer 2: Content Scanning (gitleaks)
+
+Detects 150+ secret types via built-in gitleaks rules, plus custom rules for:
+
+| Pattern | Examples |
+|---------|----------|
+| Database DSNs | `postgres://admin:s3cr3t@prod.db.com:5432/mydb` |
+| Redis DSNs | `redis://user:pass@cache.prod.com:6379` |
+| MongoDB DSNs | `mongodb+srv://admin:pass@cluster.mongodb.net` |
+| AMQP DSNs | `amqp://user:pass@rabbitmq.prod.com:5672` |
+| AWS keys | `AKIAIOSFODNN7EXAMPLE` |
+| GitHub tokens | `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` |
+| Private keys | `-----BEGIN RSA PRIVATE KEY-----` |
+| ...and 150+ more | See [gitleaks rules](https://github.com/gitleaks/gitleaks#rules) |
+
+Scanning applies to: **Read** (file content), **Write** (content to write), **Edit** (replacement text).
+
+**Allowlisted** (not blocked): localhost DSNs, common test credentials (`user:password`), Docker Compose service names (`@db:5432`), example domains.
 
 ## Prerequisites
 
-- **jq** — JSON processor
+- **jq** — JSON processor (required)
+- **gitleaks** — Secret scanner (optional, recommended)
 
 ```bash
 # Ubuntu / Debian
@@ -25,9 +54,11 @@ sudo apt install jq
 
 # macOS
 brew install jq
+brew install gitleaks
 
 # Rocky / RHEL / Fedora
 sudo dnf install jq
+# gitleaks: https://github.com/gitleaks/gitleaks#installation
 ```
 
 ## Installation
@@ -40,15 +71,17 @@ sudo dnf install jq
 
 This will:
 1. Copy `no-leak.sh` to `~/.claude/no-leak.sh`
-2. Back up your current `~/.claude/settings.json`
-3. Merge the `PreToolUse` hook into settings (all other keys are preserved)
+2. Copy `gitleaks.toml` to `~/.claude/gitleaks.toml`
+3. Back up your current `~/.claude/settings.json`
+4. Merge the `PreToolUse` hook into settings (all other keys are preserved)
 
 ### Manual
 
-1. Copy the script:
+1. Copy the scripts:
    ```bash
    cp no-leak/no-leak.sh ~/.claude/no-leak.sh
    chmod +x ~/.claude/no-leak.sh
+   cp no-leak/gitleaks.toml ~/.claude/gitleaks.toml
    ```
 
 2. Edit `~/.claude/settings.json` and add the hook:
@@ -74,7 +107,7 @@ This will:
 
 ## Testing
 
-Pipe mock JSON to verify blocking and allowing:
+### Filename pattern checks
 
 ```bash
 # Should BLOCK (exit code 2)
@@ -101,7 +134,39 @@ echo '{"tool_name":"Bash","tool_input":{"command":"go test ./..."}}' | ~/.claude
 echo $?  # 0
 ```
 
+### Content scanning (requires gitleaks)
+
+```bash
+# Should BLOCK — Write containing an AWS key
+echo '{"tool_name":"Write","tool_input":{"file_path":"config.yml","content":"aws_key = AKIAIOSFODNN7EXAMPLO"}}' | ~/.claude/no-leak.sh
+echo $?  # 2
+
+# Should BLOCK — Write with production DSN
+echo '{"tool_name":"Write","tool_input":{"file_path":"app.yml","content":"dsn: postgres://admin:s3cr3t@prod.db.company.com:5432/mydb"}}' | ~/.claude/no-leak.sh
+echo $?  # 2
+
+# Should BLOCK — Read a file containing secrets
+echo 'AKIAIOSFODNN7EXAMPLO' > /tmp/test-leak.txt
+echo '{"tool_name":"Read","tool_input":{"file_path":"/tmp/test-leak.txt"}}' | ~/.claude/no-leak.sh
+echo $?  # 2
+rm /tmp/test-leak.txt
+
+# Should ALLOW — localhost DSN (allowlisted)
+echo '{"tool_name":"Write","tool_input":{"file_path":"dev.yml","content":"dsn: postgres://user:password@localhost:5432/mydb"}}' | ~/.claude/no-leak.sh
+echo $?  # 0
+
+# Should ALLOW — Docker Compose service name (allowlisted)
+echo '{"tool_name":"Write","tool_input":{"file_path":"docker-compose.yml","content":"DATABASE_URL=postgres://user:pass@db:5432/mydb"}}' | ~/.claude/no-leak.sh
+echo $?  # 0
+
+# Should ALLOW — clean content
+echo '{"tool_name":"Write","tool_input":{"file_path":"main.go","content":"package main"}}' | ~/.claude/no-leak.sh
+echo $?  # 0
+```
+
 ## Customization
+
+### Filename patterns
 
 Edit `~/.claude/no-leak.sh` to adjust the `BLOCKED_PATTERNS` array:
 
@@ -120,6 +185,33 @@ BLOCKED_PATTERNS=(
   'kubeconfig'         # Kubernetes config
   '\.docker/config'    # Docker credentials
 )
+```
+
+### Gitleaks rules
+
+Edit `~/.claude/gitleaks.toml` to customize content scanning:
+
+```toml
+[extend]
+useDefault = true
+
+# Disable a noisy built-in rule
+# disabledRules = ["generic-api-key"]
+
+# Add project-specific allowlist
+[[allowlists]]
+description = "Allow test fixtures"
+paths = ['''tests/fixtures/.*''']
+```
+
+See the [gitleaks configuration docs](https://github.com/gitleaks/gitleaks#configuration) for the full schema.
+
+### Disabling gitleaks temporarily
+
+Set the environment variable before running Claude Code:
+
+```bash
+GITLEAKS_DISABLED=1 claude
 ```
 
 ## Reverting
@@ -142,6 +234,9 @@ Or manually remove the `PreToolUse` hook entry from `~/.claude/settings.json`.
 |---------|-------|-----|
 | Hook not triggering | Script not executable | `chmod +x ~/.claude/no-leak.sh` |
 | `jq not found` in stderr | jq not installed | Install jq (see Prerequisites) |
-| False positive on normal file | Pattern too broad | Narrow the regex in `BLOCKED_PATTERNS` |
+| False positive on filename | Pattern too broad | Narrow the regex in `BLOCKED_PATTERNS` |
+| False positive on content | Gitleaks rule too strict | Add allowlist entry in `~/.claude/gitleaks.toml` |
 | Hook not active after install | Claude Code not restarted | Restart Claude Code |
 | Existing hooks overwritten | Manual edit conflict | Re-run `configure-no-leak.sh` (uses smart merge) |
+| Content scan not working | gitleaks not installed | `brew install gitleaks` or see Prerequisites |
+| Want to skip content scan | Temporary bypass needed | `GITLEAKS_DISABLED=1 claude` |

--- a/extras/no-leak/no-leak.sh
+++ b/extras/no-leak/no-leak.sh
@@ -1,26 +1,40 @@
 #!/usr/bin/env bash
-# Claude Code PreToolUse hook — block access to sensitive files
+# Claude Code PreToolUse hook — block access to sensitive files and content
 # Receives JSON on stdin, exits 2 to block or 0 to allow.
+#
+# Layer 1: Filename pattern matching (always active, requires jq)
+# Layer 2: Content scanning via gitleaks (if installed, graceful degradation)
 
 set -euo pipefail
 
 INPUT=$(cat)
 
-# Check jq is available
+# --- Prerequisites ---
+
 if ! command -v jq &>/dev/null; then
   echo "no-leak: jq not found, skipping check" >&2
   exit 0
 fi
 
+# --- Gitleaks availability ---
+
+GITLEAKS_AVAILABLE=false
+GITLEAKS_CONFIG="$HOME/.claude/gitleaks.toml"
+
+if [[ "${GITLEAKS_DISABLED:-}" == "1" ]]; then
+  : # explicitly disabled by user
+elif command -v gitleaks &>/dev/null; then
+  GITLEAKS_AVAILABLE=true
+fi
+
+# --- Parse input ---
+
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
-
-# Extract file path from tool_input (Read, Edit, Write, Glob)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // ""')
-
-# For Bash, extract the command string
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
-# Patterns that indicate sensitive files (matched against basename)
+# --- Blocked filename patterns ---
+
 BLOCKED_PATTERNS=(
   '\.env$'
   '\.env\.'
@@ -44,12 +58,45 @@ check_path() {
   done
 }
 
-# --- File-based tools (Read, Edit, Write, Glob) ---
+# --- Gitleaks content scan function ---
+
+scan_with_gitleaks() {
+  [[ "$GITLEAKS_AVAILABLE" == "true" ]] || return 0
+
+  local mode="$1"
+  local config_args=()
+  if [[ -f "$GITLEAKS_CONFIG" ]]; then
+    config_args=(--config "$GITLEAKS_CONFIG")
+  fi
+
+  local gitleaks_exit=0
+
+  if [[ "$mode" == "file" ]]; then
+    local filepath="$2"
+    # Skip if file doesn't exist (Claude Code itself will report the error)
+    [[ -f "$filepath" ]] || return 0
+    gitleaks dir "${config_args[@]}" --no-banner --exit-code 99 --max-target-megabytes 1 "$filepath" 2>/dev/null || gitleaks_exit=$?
+  elif [[ "$mode" == "stdin" ]]; then
+    local content="$2"
+    [[ -n "$content" ]] || return 0
+    printf '%s\n' "$content" | gitleaks stdin "${config_args[@]}" --no-banner --exit-code 99 2>/dev/null || gitleaks_exit=$?
+  fi
+
+  if [[ "$gitleaks_exit" -eq 99 ]]; then
+    echo "Blocked: gitleaks detected secrets in content. Review the content before proceeding." >&2
+    exit 2
+  fi
+  # Exit codes 0 (clean) and others (gitleaks error) both allow the operation.
+  # We only block on exit 99 (confirmed leaks).
+  return 0
+}
+
+# --- Layer 1: Filename pattern checks ---
+
 if [[ -n "$FILE_PATH" ]]; then
   check_path "$FILE_PATH"
 fi
 
-# --- Bash commands referencing sensitive files ---
 if [[ "$TOOL_NAME" == "Bash" && -n "$COMMAND" ]]; then
   for pattern in "${BLOCKED_PATTERNS[@]}"; do
     if [[ "$COMMAND" =~ $pattern ]]; then
@@ -57,6 +104,30 @@ if [[ "$TOOL_NAME" == "Bash" && -n "$COMMAND" ]]; then
       exit 2
     fi
   done
+fi
+
+# --- Layer 2: Content scanning with gitleaks ---
+
+if [[ "$GITLEAKS_AVAILABLE" == "true" ]]; then
+  case "$TOOL_NAME" in
+    Read)
+      if [[ -n "$FILE_PATH" ]]; then
+        scan_with_gitleaks "file" "$FILE_PATH"
+      fi
+      ;;
+    Write)
+      CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // ""')
+      if [[ -n "$CONTENT" ]]; then
+        scan_with_gitleaks "stdin" "$CONTENT"
+      fi
+      ;;
+    Edit)
+      NEW_STRING=$(echo "$INPUT" | jq -r '.tool_input.new_string // ""')
+      if [[ -n "$NEW_STRING" ]]; then
+        scan_with_gitleaks "stdin" "$NEW_STRING"
+      fi
+      ;;
+  esac
 fi
 
 exit 0


### PR DESCRIPTION
Add gitleaks integration to no-leak PreToolUse hook for content-based
scanning of Read/Write/Edit tool calls. Layer 1 (filename patterns)
remains unchanged; Layer 2 scans file content via gitleaks with graceful
degradation when gitleaks is not installed.

- no-leak.sh: scan_with_gitleaks() using gitleaks dir/stdin modes
  with --exit-code 99 and GITLEAKS_DISABLED=1 escape hatch
- configure-no-leak.sh: soft gitleaks check and config installation
- gitleaks.toml: custom DSN credential rules with allowlists for
  localhost, test credentials, and docker-compose service names
- install-no-leak.md: updated docs for two-layer protection model

Closes #144