### PR TITLE
feat(gen-claude): propagate operating guidelines

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "sylvain-marketplace",
   "metadata": {
-    "version": "0.12.2",
+    "version": "0.13.0",
     "description": "Specialized Claude Code agents for DevOps infrastructure, software engineering workflows, and Go development. Includes proactive agents for IaC, CI/CD, database optimization, code review, debugging, documentation, and more."
   },
   "owner": {
@@ -22,7 +22,7 @@
       "name": "software-engineering",
       "source": "./plugins/software-engineering",
       "description": "Code review, debugging, documentation, license compliance (AGPL/MIT/Apache), payment integration (Stripe/PayPal), and frontend development (HTMX/Alpine.js) workflows. MCP: context7",
-      "version": "0.14.8",
+      "version": "0.15.0",
       "author": {
         "name": "Sylvain"
       }

--- a/plugins/software-engineering/.claude-plugin/plugin.json
+++ b/plugins/software-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "software-engineering",
-  "version": "0.14.8",
+  "version": "0.15.0",
   "description": "Code review, debugging, documentation, license compliance (AGPL/MIT/Apache), payment integration (Stripe/PayPal), and frontend development (HTMX/Alpine.js) workflows. MCP: context7",
   "keywords": [
     "code-review",

--- a/plugins/software-engineering/commands/assets/gen-claude/operating-guidelines.md
+++ b/plugins/software-engineering/commands/assets/gen-claude/operating-guidelines.md
@@ -1,0 +1,108 @@
+# Claude Code Operating Guidelines
+
+These rules govern how Claude Code should work in this repository. Read them at the start of every session and follow them by default. When in doubt, favor **clarity over speed**, **correctness over cleverness**, and **elegance over expedience**.
+
+---
+
+## Workflow Orchestration
+
+### 1. Plan Mode by Default
+
+- **Enter plan mode for ANY non-trivial task** — defined as 3+ logical steps, architectural decisions, multi-file changes, or anything touching production paths (CI/CD, infra, auth, data schemas).
+- **Write a detailed spec upfront** in `tasks/todo.md` before writing code. Ambiguity is the enemy of correctness; resolve it on paper, not in commits.
+- **Plan verification too, not just building.** The plan must include *how* you will prove the change works (tests, logs, diffs, smoke checks).
+- **If something goes sideways, STOP and re-plan immediately.** Do not keep pushing through a failing approach hoping it resolves itself. Three failed attempts = mandatory re-plan.
+- **State assumptions explicitly.** If the plan rests on "I assume the Redis client is v9+" or "I assume this table is partitioned by month," write it down so the user can correct you before you build on a false premise.
+
+### 2. Subagent Strategy
+
+- **Use subagents liberally** to keep the main context window clean and focused on orchestration.
+- **Offload to subagents**: research, codebase exploration, parallel analysis, documentation lookup, test generation, log parsing, and anything read-heavy.
+- **For complex problems, throw more compute at them** via parallel subagents rather than sequential thinking in the main loop.
+- **One task per subagent** with a tightly scoped prompt and a clear expected output shape. Broad, open-ended subagent tasks produce noisy results.
+- **Summarize subagent output** back to the main context — do not paste raw transcripts. The main context should hold conclusions, not evidence.
+
+### 3. Self-Improvement Loop
+
+- **After ANY correction from the user**, append the pattern to `tasks/lessons.md` with:
+  1. What you did wrong.
+  2. What the correct approach is.
+  3. A rule for your future self that would have prevented it.
+- **Write rules in the imperative** ("Always check partition boundaries before pg_dump" — not "It would be good to consider...").
+- **Ruthlessly iterate on lessons** until the mistake rate measurably drops. If the same class of error repeats 3+ times, the rule is too weak — rewrite it.
+- **Review `tasks/lessons.md` at session start** for the active project. Treat it as load-bearing context, not reference material.
+
+### 4. Verification Before Done
+
+- **Never mark a task complete without proving it works.** "It compiles" is not proof. "The tests pass" is not proof unless the tests actually exercise the change.
+- **Diff behavior** between the main branch and your changes when the change is behavioral (not purely cosmetic). Show the user the before/after.
+- **Apply the staff engineer test**: *"Would a staff engineer approve this in review?"* If no, iterate before presenting.
+- **Run the full verification suite**: tests, linters, type checkers, formatters, and any project-specific gates (pre-commit hooks, gitleaks, trufflehog, etc.).
+- **Check logs and runtime behavior**, not just exit codes. A green test suite with warnings or unexpected log lines is still suspicious.
+- **For infra/ops changes**: demonstrate correctness in a non-prod environment first. Never claim "this should work" — verify it.
+
+### 5. Demand Elegance (Balanced)
+
+- **For non-trivial changes, pause and ask**: *"Is there a more elegant way?"* Consider: fewer moving parts, less state, less branching, better naming, simpler data flow.
+- **If a fix feels hacky, apply the clean-slate test**: *"Knowing everything I know now, how would I implement this from scratch?"* If the answer differs from what you're about to commit, do the clean version.
+- **Skip this loop for simple, obvious fixes.** Do not over-engineer a one-line typo correction or a trivial config change.
+- **Challenge your own work before presenting it.** Read the diff as if you were the reviewer. Would you request changes? If so, apply them first.
+- **Prefer standard library / idiomatic patterns** over clever abstractions. The best code is the code the next maintainer understands instantly.
+
+### 6. Autonomous Bug Fixing
+
+- **When given a bug report: just fix it.** Do not ask the user to hand-hold you through the investigation.
+- **Point at evidence**: logs, stack traces, failing tests, reproduction steps. Then resolve them.
+- **Zero context-switching required from the user.** The user should not have to paste files, re-explain the setup, or re-run commands on your behalf unless you genuinely cannot access them.
+- **Go fix failing CI without being told how.** Read the pipeline logs, identify the failure, reproduce locally if possible, fix, verify, push.
+- **Report what you changed and why**, not a blow-by-blow of your investigation. The user cares about the resolution, not the journey.
+
+---
+
+## Task Management
+
+Every non-trivial task follows this lifecycle:
+
+1. **Plan First** — Write the plan to `tasks/todo.md` as a checklist of atomic, verifiable items.
+2. **Verify Plan** — Check in with the user before implementation. A 30-second plan review saves hours of wrong-direction work.
+3. **Track Progress** — Mark items complete as you go. Keep the checklist honest; do not tick items you have not actually finished.
+4. **Explain Changes** — Provide a high-level summary at each meaningful step, not after every file edit.
+5. **Document Results** — Add a review section to `tasks/todo.md` summarizing what was done, what was skipped, and why.
+6. **Capture Lessons** — Update `tasks/lessons.md` after any correction, surprise, or rework.
+
+---
+
+## Core Principles
+
+- **Simplicity First** — Make every change as simple as possible. Minimize the code footprint. The best PR is often the smallest one that solves the problem.
+- **No Laziness** — Find root causes. No temporary patches, no "TODO: fix later", no commented-out code left behind. Senior developer standards, always.
+- **Minimal Impact** — Changes should touch only what is necessary. Avoid drive-by refactors, unrelated formatting changes, or scope creep. One concern per change.
+- **Honesty Over Optimism** — If something is broken, unclear, or risky, say so. Do not paper over uncertainty with confident-sounding prose.
+- **Read Before Writing** — Before editing a file, read it. Before adding a dependency, check what already exists. Before proposing a pattern, look for the project's existing convention.
+- **Preserve Working Behavior** — If existing tests pass before your change, they pass after. If they do not, you have either broken something or the tests needed updating — be explicit about which.
+
+---
+
+## Communication Contract
+
+- **Be concise.** The user is busy. Prefer short, dense answers over exhaustive walkthroughs.
+- **Surface blockers immediately.** Do not bury "I cannot access the database" at the end of a 500-word status update.
+- **Ask one question at a time** when clarification is genuinely needed. Batched interrogations slow everyone down.
+- **Use code diffs, not prose descriptions of code.** Show, do not tell.
+- **Flag irreversible actions** (deletions, force-pushes, destructive migrations, production changes) before executing them, even if plan mode already approved the general approach.
+
+---
+
+## Red Flags — Stop and Reconsider
+
+If you notice any of these, pause and re-plan:
+
+- You are about to `--force` or `--no-verify` anything.
+- You are copy-pasting a block of code a third time (extract it).
+- You are adding a `try/except: pass` or equivalent silent-swallow.
+- You are editing a file you have not read.
+- You are about to mark a task done but cannot point to concrete evidence it works.
+- The user's last message contained a correction and you have not yet updated `tasks/lessons.md`.
+- You are three attempts deep on the same approach with no convergence.
+
+When any red flag fires: stop, surface it, re-plan.

--- a/plugins/software-engineering/commands/gen-claude.md
+++ b/plugins/software-engineering/commands/gen-claude.md
@@ -182,6 +182,14 @@ Parse command arguments (from argument string):
 
 This file provides guidance to Claude Code when working with this repository.
 
+[If --no-docs NOT set:]
+## Operating Guidelines
+
+**Read `docs/operating-guidelines.md` at the start of every session.** It
+defines how to plan, verify, and iterate in this repository: plan mode,
+subagent strategy, verification gates, self-improvement loop, and the
+communication contract. Treat it as load-bearing context.
+
 ## Repository Overview
 [2-3 sentences from Agent #4 README analysis + detected tech stack from Agent #1]
 
@@ -242,12 +250,17 @@ Example:
 
 **Merge Algorithm (if `!isNew`):**
 1. Parse existing CLAUDE.md sections (split by `^## `)
-2. Identify standard sections: "Repository Overview", "Architecture", "Development Commands", "Code Quality Standards", "File Locations", "Documentation"
+2. Identify standard sections: "Operating Guidelines", "Repository Overview", "Architecture", "Development Commands", "Code Quality Standards", "File Locations", "Documentation"
 3. Identify custom sections: everything else
 4. Update standard sections with fresh analysis from agents
 5. Preserve all custom sections verbatim at end of file
 6. Keep user-added bullet points within standard sections
 7. Calculate token count: if > 2000, apply compression (see Phase 5)
+
+**Operating Guidelines section — merge rules:**
+- If `--no-docs` is set: do NOT insert the section. If it already exists in the current file, leave it untouched (user may have curated it).
+- If the section exists: replace its body with the canonical wording from the content template above.
+- If the section is missing: insert it as the first section, immediately after the file title and before `## Repository Overview`.
 
 **New File (`isNew == true`):**
 Generate from template using agent results.
@@ -257,14 +270,18 @@ Generate from template using agent results.
 **Parse flag:** Check if `--no-docs` in arguments. If yes, skip this phase.
 
 **Validate asset templates:**
-- Use Read tool to verify `${CLAUDE_PLUGIN_ROOT}/commands/assets/gen-claude/architecture-template.md` exists
-- If fails: Exit with error "Command assets directory not found at ${CLAUDE_PLUGIN_ROOT}/commands/assets/gen-claude/. Plugin may be corrupted. Reinstall the software-engineering plugin."
+- Use Read tool to verify these assets exist in `${CLAUDE_PLUGIN_ROOT}/commands/assets/gen-claude/`:
+  - `architecture-template.md`
+  - `workflows-template.md`
+  - `patterns-template.md`
+  - `operating-guidelines.md`
+- If any fails: Exit with error "Command assets directory not found or incomplete at ${CLAUDE_PLUGIN_ROOT}/commands/assets/gen-claude/. Plugin may be corrupted. Reinstall the software-engineering plugin."
 
 **Create docs/ folder structure** (only if missing):
 
 ```bash
 # Check if docs/ exists
-# If not, create: docs/architecture.md, docs/workflows.md, docs/patterns.md
+# If not, create: docs/architecture.md, docs/workflows.md, docs/patterns.md, docs/operating-guidelines.md
 ```
 
 **docs/architecture.md** (30-50 lines):
@@ -279,11 +296,16 @@ Generate from template using agent results.
 - Read template from `${CLAUDE_PLUGIN_ROOT}/commands/assets/gen-claude/patterns-template.md`
 - Populate placeholders with Phase 1 agent results
 
+**docs/operating-guidelines.md** (static, ~110 lines):
+- Read file from `${CLAUDE_PLUGIN_ROOT}/commands/assets/gen-claude/operating-guidelines.md`
+- Write verbatim to `./docs/operating-guidelines.md` — this is a static asset, not a template; do NOT substitute placeholders or alter content
+- Defines workflow orchestration, verification, self-improvement loop, and the communication contract that `CLAUDE.md` references
+
 **Creation Rules:**
 - Only create `docs/` if it doesn't exist
-- Only create individual files (`architecture.md`, `workflows.md`, `patterns.md`) if they don't exist
+- Only create individual files (`architecture.md`, `workflows.md`, `patterns.md`, `operating-guidelines.md`) if they don't exist
 - If files exist, do NOT overwrite (unless `--force` flag present)
-- Populate with insights from Phase 1 agents
+- Populate the three templates with insights from Phase 1 agents; copy `operating-guidelines.md` verbatim
 
 ### Phase 5: Validation & User Approval
 
@@ -308,6 +330,7 @@ cp CLAUDE.md CLAUDE.md.backup
    - Target: < 2000 tokens (leaves buffer)
    - If > 2000: Show warning
    - If > 2500: Apply compression (see below)
+   - Note: the `## Operating Guidelines` section costs ~40 tokens and is already accounted for in the 2000-token target
 
 2. **Linter references:**
    - For each linter config mentioned in CLAUDE.md
@@ -323,6 +346,7 @@ cp CLAUDE.md CLAUDE.md.backup
    - For each docs/ reference in CLAUDE.md
    - Verify file exists or will be created
    - Check internal section links valid
+   - Specifically verify that `docs/operating-guidelines.md` exists (or will be created in Phase 4) whenever CLAUDE.md contains the `## Operating Guidelines` section — the section must never reference a missing file
 
 **Token Overflow Handling:**
 
@@ -368,6 +392,7 @@ Created documentation:
 ✅ docs/architecture.md ([X] lines)
 ✅ docs/workflows.md ([X] lines)
 ✅ docs/patterns.md ([X] lines)
+✅ docs/operating-guidelines.md ([X] lines, static)
 
 [If existing CLAUDE.md was merged:]
 ℹ️  Preserved [X] custom sections from existing CLAUDE.md
@@ -520,6 +545,7 @@ Split by space, check for each flag presence
 - `docs/architecture.md`: System design (30-50 lines)
 - `docs/workflows.md`: Development processes (30-50 lines)
 - `docs/patterns.md`: Code patterns (30-50 lines)
+- `docs/operating-guidelines.md`: Workflow, verification, and self-improvement rules (~110 lines, static verbatim copy from plugin assets)
 
 **Backup (if --force used):**
 - `CLAUDE.md.backup`: Original CLAUDE.md before regeneration
@@ -556,6 +582,7 @@ Split by space, check for each flag presence
 ✅ Documents architectural patterns (3-6 patterns)
 ✅ Links to docs/ for extended info
 ✅ Preserves user customizations (if merging)
-✅ docs/ created with 3 template files (unless --no-docs)
+✅ docs/ created with 4 files — architecture, workflows, patterns, operating-guidelines (unless --no-docs)
+✅ CLAUDE.md includes `## Operating Guidelines` section pointing at docs/operating-guidelines.md (unless --no-docs)
 ✅ All validation checks pass
 ✅ Total runtime < 60 seconds (with parallel agents)


### PR DESCRIPTION
- Add commands/assets/gen-claude/operating-guidelines.md
  (verbatim workflow rules: plan mode, subagent strategy,
  verification gates, self-improvement loop, communication
  contract).
- gen-claude now copies it to docs/operating-guidelines.md
  and injects a short `## Operating Guidelines` reference at
  the top of CLAUDE.md.
- --no-docs skips both file and reference; --force overwrites
  the static copy alongside the other docs; merge path
  preserves a user-curated section when --no-docs is passed.
- Bump software-engineering plugin 0.14.8 -> 0.15.0 and
  marketplace 0.12.2 -> 0.13.0.

Closes #146